### PR TITLE
Update link to APIDays API Landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,6 @@ If you want to dive deeper into the developer rabbit hole, I recommend:
 
 4. [TheNewStack.io](https://TheNewStack.io) has emerged as one of my favorite reading spots to get a feel for how different vendors are positioning underlying shifts in the industry. They are one of the few analyst publications focused on infrastructure that has a dedicated section to development.
 
-5. The [APIDays API Landscape by Mehdi Medjaoui](https://www.apidays.co/wp-content/uploads/2020/07/API-Landscape-2020.pdf) does an excellent job of capturing the different categories of infrastructre that go into supporting the API lifecycle.
+5. The [APIDays API Landscape by Mehdi Medjaoui](https://www.apidays.global/wp-content/uploads/2020/07/API-Landscape-2020.pdf) does an excellent job of capturing the different categories of infrastructre that go into supporting the API lifecycle.
 
 6. There are other VCs that sometimes write about developer markets, and their writings can offer insights not commonly seen elsewhere. This includes [Assaf Araki on Autonomous Software Development](https://www.linkedin.com/pulse/software-20-takes-shape-assaf-araki/?trackingId=BXbKWfcyRQOoKMQJU4dCOw%3D%3D), [Astasia Meyers' Memory Leak](https://medium.com/memory-leak/3-devops-trends-to-watch-in-2020-827f69475ff0) and [Nnamdi Iregbulem's WhoIsNnamdi](https://whoisnnamdi.com/).


### PR DESCRIPTION
Previous version link was 404ing as the TLD has changed from apidays.co to apidays.global